### PR TITLE
Fixed Broken Links

### DIFF
--- a/about/6-web3-up-close.md
+++ b/about/6-web3-up-close.md
@@ -117,19 +117,19 @@ Web3 project is a website, program, or app that’s built using decentralized te
 
 #### Web3 Authentication
 
-[Web3 Authentication](/web3-services/1-good-to-know.html#web3-authentication) is a Web3 service that enables decentralized verification of unique sets of data, identities, and assets. The Apillon platform offers Web3 authentication services powered by KILT Protocol, which delivers secure identity solutions and credentials for enterprises and consumers.
+[Web3 Authentication](/web3-services/5-web3-authentication.md) is a Web3 service that enables decentralized verification of unique sets of data, identities, and assets. The Apillon platform offers Web3 authentication services powered by KILT Protocol, which delivers secure identity solutions and credentials for enterprises and consumers.
 
 #### Web3 Storage
 
-[Web3 Storage](/web3-services/1-good-to-know.html#web3-storage) is a Web3 service that connects to a decentralized network of computer nodes to store the files of a website or app, increasing accessibility and eliminating a single point of access. As the files get stored on a decentralized network of nodes, they become unstoppable. The Apillon platform delivers Web3 Storage service powered by Crust Network.
+[Web3 Storage](/web3-services/2-web3-storage.md) is a Web3 service that connects to a decentralized network of computer nodes to store the files of a website or app, increasing accessibility and eliminating a single point of access. As the files get stored on a decentralized network of nodes, they become unstoppable. The Apillon platform delivers Web3 Storage service powered by Crust Network.
 
 #### Web3 Hosting
 
-[Web3 Hosting](/web3-services/1-good-to-know.html#web3-hosting) is a Web3 service that connects to a decentralized network of computer nodes to host a website or app, increasing its accessibility and eliminating a single point of access. As the website or app gets hosted on a decentralized network of nodes, it becomes unstoppable. The Apillon platform delivers Web3 Hosting service powered by Crust Network.
+[Web3 Hosting](/web3-services/3-web3-hosting.md) is a Web3 service that connects to a decentralized network of computer nodes to host a website or app, increasing its accessibility and eliminating a single point of access. As the website or app gets hosted on a decentralized network of nodes, it becomes unstoppable. The Apillon platform delivers Web3 Hosting service powered by Crust Network.
 
 #### Web3 Computing
 
-[Web3 Computing](/web3-services/1-good-to-know.html#web3-computing) is a Web3 service that offers decentralized cloud computing power by connecting to a peer-to-peer network of computer nodes. This provides privacy, security, and data confidentiality. The Apillon platform delivers Web3 Computing service, powered by Phala Network.
+[Web3 Computing](/web3-services/7-web3-compute.md) is a Web3 service that offers decentralized cloud computing power by connecting to a peer-to-peer network of computer nodes. This provides privacy, security, and data confidentiality. The Apillon platform delivers Web3 Computing service, powered by Phala Network.
 
 #### Unified service pricing
 

--- a/web3-services/4-nfts.md
+++ b/web3-services/4-nfts.md
@@ -2,7 +2,7 @@
 
 Apillon NFT service supports drag-and-drop compilation, deployment, and minting of non-fungible assets.
 
-The service is currenly supported by the [Moonbeam Network](https://blog.apillon.io/guide-nft-service-pt-2-create-and-deploy-nft-collection-on-moonbeam-2d7eedf79756) and [Astar Network](https://blog.apillon.io/guide-nft-service-create-and-deploy-nft-collection-on-astar-3d6674994b0f) for EVM and Astar network for substrate based NFTs.
+The service is currently supported by the [Moonbeam Network](https://blog.apillon.io/guide-nft-service-pt-2-create-and-deploy-nft-collection-on-moonbeam-2d7eedf79756) and [Astar Network](https://blog.apillon.io/guide-nft-service-create-and-deploy-nft-collection-on-astar-3d6674994b0f) for EVM and Astar network for substrate based NFTs.
 
 ## NFT files
 

--- a/web3-services/6-web3-social.md
+++ b/web3-services/6-web3-social.md
@@ -2,11 +2,11 @@
 
 Apillon offers web3 alternatives for social networking between end users. This is powered by [subsocial network](https://subsocial.network/).
 
-Currently Apillon offers web3 chat alternative called [grill chat](https://grillapp.net/c/hot-chats) that allows anonymous chatting which content can be displayed anywhere integrating the subsocial grill chat.
+Currently, Apillon offers a web3 chat alternative called [grill chat](https://grillapp.net/c/hot-chats) that allows anonymous chatting in which content can be displayed anywhere integrating the subsocial grill chat.
 
 ## Chat
 
-You can create the chat rooms via Apillon dashboard and integrate grill chat widget into you page via `html` and `javascript`. You can also manage you chat rooms via API and SDK for simple on the fly creation.
+You can create the chat rooms via Apillon dashboard and integrate the grill chat widget into your page via `html` and `javascript`. You can also manage your chat rooms via API and SDK for simple on the fly creation.
 
 You can create a single chat room or a hub containing multiple chat rooms.
 


### PR DESCRIPTION
Earlier links weren't working for me and every link from `Web3 Authentication` to `Web3 Computing` navigating to [this](https://wiki.apillon.io/web3-services/1-good-to-know.html#ipfs)

Guess now they are correct, still do make the necessary checks!